### PR TITLE
Fix callback memory leak

### DIFF
--- a/src/visualisation/wandb_callbacks/image_classification_callback.py
+++ b/src/visualisation/wandb_callbacks/image_classification_callback.py
@@ -55,23 +55,39 @@ class WandbImageClassificationCallback(pl.Callback):
     def on_train_batch_end(
         self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
     ):
-        self._log_examples(
-            trainer,
-            outputs["imgs"],
-            outputs["logits"],
-            outputs["targets"],
-            mode="train",
-        )
-        self._log_logits(trainer, outputs["logits"], mode="train")
+        if (batch_idx + 1) % trainer.log_every_n_steps == 0:
+            imgs, targets = batch
+
+            with torch.no_grad():
+                pl_module.eval()
+                logits = pl_module(imgs)
+                pl_module.train()
+
+            self._log_examples(
+                trainer,
+                imgs,
+                logits,
+                targets,
+                mode="train",
+            )
+            self._log_logits(trainer, logits, mode="train")
 
     def on_validation_batch_end(
         self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
     ):
-        self._log_examples(
-            trainer,
-            outputs["imgs"],
-            outputs["logits"],
-            outputs["targets"],
-            mode="validation",
-        )
-        self._log_logits(trainer, outputs["logits"], mode="validation")
+        if (batch_idx + 1) % trainer.log_every_n_steps == 0:
+            imgs, targets = batch
+
+            with torch.no_grad():
+                pl_module.eval()
+                logits = pl_module(imgs)
+                pl_module.train()
+
+            self._log_examples(
+                trainer,
+                imgs,
+                logits,
+                targets,
+                mode="validation",
+            )
+            self._log_logits(trainer, logits, mode="validation")


### PR DESCRIPTION
## Summary of changes made
* Fix memory leak in callbacks by only returning loss and acc from step and recalculating logits in the callback
* trigger the callback with trainer.log_every_n_steps
* create _step base method in model to reduce code repetition
* [Resolves #7  ]

## Screenshots
![image](https://user-images.githubusercontent.com/46627645/134183240-8ae5f176-1ba4-4810-bbc9-831fbad88c49.png)
![image](https://user-images.githubusercontent.com/46627645/134183312-a1c49fea-aeb2-4d91-ba10-5daf48d0aa6b.png)

## Testing
* Results from screenshots show less overall memory use and slower increase in memory over epoch (brown line on graph).
* Some increase is still expected because loss and accuracy tensors are cached (but these should be small)

## Code Quality
* [x] Passes static analysis checks
* [x] Code is black formatted
* [N/A] Unit tests written and passed

## Checklist
* [x] Added PR label(s)
* [x] Added linked issue
